### PR TITLE
Add colors to tags

### DIFF
--- a/mint-tags-display.user.js
+++ b/mint-tags-display.user.js
@@ -89,7 +89,7 @@
       jQuery.each( tags, function( index, value ){
         // if tag exists, pull color from tagColorIndex array
         // if not, assign tag to tagColorIndex array, assign next color in order
-        if (!(value in tagColorIndex)) {
+        if (!(value in tagColorLookup)) {
             tagColorLookup[value] = tagColors[ Object.keys(tagColorLookup).length ];
         }
       });

--- a/mint-tags-display.user.js
+++ b/mint-tags-display.user.js
@@ -16,8 +16,11 @@
 
 (function() {
   // tweak tag style: (default colors were chosen for consistency with Mint's theme)
-  var TAG_STYLE = 'background: #0AC775; color: white; font-size: 10px; display: inline-block; margin-left: 4px; padding: 0 2px';
-
+  var TAG_STYLE = 'color: white; font-size: 10px; display: inline-block;';
+  var SINGLE_TAG_STYLE = ' margin-left: 4px; padding: 0 2px';
+  var tagColors = ['background: #0AC775;', 'background: #6b3b2b;','background: #6b552b;', 'background: #212b47;', 'background: #1E4A35;'];
+  var tagColorLookup = [];
+    
   var transIdToTags = {};
   var tagIdToName = {};
 
@@ -73,6 +76,7 @@
     });
   }
 
+    
   // update a transaction row using cached tag data
   function updateRow(rowId) {
     var $td = jQuery('#' + rowId).find('td.cat');
@@ -81,7 +85,21 @@
       if($td.find('.gm-tags').length === 0) {
         $td.append('<span class="gm-tags" style="' + TAG_STYLE + '"></span>');
       }
-      $td.find('.gm-tags').text(transIdToTags[transId]);
+      tags = transIdToTags[transId].split(',');
+      jQuery.each( tags, function( index, value ){
+        // if tag exists, pull color from tagColorIndex array
+        // if not, assign tag to tagColorIndex array, assign next color in order
+        if (!(value in tagColorIndex)) {
+            tagColorLookup[value] = tagColors[ Object.keys(tagColorLookup).length ];
+        }
+      });
+      tagsHTML = [];
+      jQuery.each( tags, function( index, value ){
+        tagsHTML.push('<span class="gm-tag" style="' + tagColorLookup[value] + SINGLE_TAG_STYLE + '">' + value + '</span>');
+      });
+      
+      $td.find('.gm-tags').html(tagsHTML);
+            
     } else {
       $td.find('.gm-tags').remove();
     }

--- a/mint-tags-display.user.js
+++ b/mint-tags-display.user.js
@@ -18,9 +18,27 @@
   // tweak tag style: (default colors were chosen for consistency with Mint's theme)
   var TAG_STYLE = 'color: white; font-size: 10px; display: inline-block;';
   var SINGLE_TAG_STYLE = ' margin-left: 4px; padding: 0 2px';
-  var tagColors = ['background: #0AC775;', 'background: #6b3b2b;','background: #6b552b;', 'background: #212b47;', 'background: #1E4A35;'];
-  var tagColorLookup = [];
+  var tagColors = [ 'tan',
+                    'silver',
+                    'gray',
+                    'charcoal',
+                    'royal blue',
+                    'teal',
+                    'forest green',
+                    'olive',
+                    'lime',
+                    'golden',
+                    'goldenrod',
+                    'coral',
+                    'fuchsia',
+                    'puce',
+                    'plum',
+                    'maroon',
+                    'crimson' ];
     
+  var tagColorLookup = []; // key is tag name, value is from tagColor array
+  var availableTags = [] // pulled from sidebar -- all possible tags user has
+  
   var transIdToTags = {};
   var tagIdToName = {};
 
@@ -86,16 +104,11 @@
         $td.append('<span class="gm-tags" style="' + TAG_STYLE + '"></span>');
       }
       tags = transIdToTags[transId].split(',');
-      jQuery.each( tags, function( index, value ){
-        // if tag exists, pull color from tagColorIndex array
-        // if not, assign tag to tagColorIndex array, assign next color in order
-        if (!(value in tagColorLookup)) {
-            tagColorLookup[value] = tagColors[ Object.keys(tagColorLookup).length ];
-        }
-      });
+
+      // HTML for each tag, unique color for each tag
       tagsHTML = [];
       jQuery.each( tags, function( index, value ){
-        tagsHTML.push('<span class="gm-tag" style="' + tagColorLookup[value] + SINGLE_TAG_STYLE + '">' + value + '</span>');
+        tagsHTML.push('<span class="gm-tag" style="background-color:' + tagColorLookup[value] + '; ' + SINGLE_TAG_STYLE + '">' + value + '</span>');
       });
       
       $td.find('.gm-tags').html(tagsHTML);
@@ -171,6 +184,13 @@
       return;
     }
 
+    // read in tags list from sidebar
+    jQuery( '#localnav-tags ol li' ).each(function(){
+        availableTags.push( jQuery(this).prop('title') );
+    });
+    
+    assignTagColors(availableTags);
+
     // populate the table with tags after it first loads
     jQuery(target).find('tr').each(function(_, row) {
       updateRow(row.id);
@@ -179,4 +199,19 @@
     observeDOM(target);
   })();
 
+  function assignTagColors(tags) {
+  	// populate array `tagColorLookup`
+  	// provide color from array `tagColors`
+  	// for each tag in array `tags`  	
+    colorIndex = 0;
+  	for (key in tags) {
+        tagColorLookup[tags[key]] = tagColors[colorIndex];
+        colorIndex++;
+        
+        if (colorIndex > ( tagColors.length - 1 ) ) {
+            colorIndex = 0;
+        }
+	}
+  }
+    
 })();

--- a/mint-tags-display.user.js
+++ b/mint-tags-display.user.js
@@ -5,7 +5,7 @@
 // @description Show tags in the transactions listing on Mint.com.
 // @namespace   com.warkmilson.mint.js
 // @author      Mark Wilson
-// @version     1.1.0
+// @version     1.2.0
 // @homepage    https://github.com/mddub/mint-tags-display
 // @updateURL   https://github.com/mddub/mint-tags-display/raw/master/mint-tags-display.user.js
 // @downloadURL https://github.com/mddub/mint-tags-display/raw/master/mint-tags-display.user.js

--- a/mint-tags-display.user.js
+++ b/mint-tags-display.user.js
@@ -15,9 +15,24 @@
 //
 
 (function() {
-  var TAG_STYLE = 'color: white; font-size: 10px; display: inline-block;';
+  var TAG_STYLE = 'font-size: 10px; display: inline-block;';
   var SINGLE_TAG_STYLE = 'margin-left: 4px; padding: 0 2px;';
-  var TAG_COLORS = ['tan', 'silver', 'gray', 'dimgray', 'royalblue', 'teal', 'forestgreen', 'olive', 'lime', 'golden', 'goldenrod', 'coral', 'fuchsia', 'puce', 'plum', 'maroon', 'crimson'];
+  var TAG_COLORS = [
+    // source: http://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12
+    // background, foreground
+    ['#a6cee3', 'black'],
+    ['#b2df8a', 'black'],
+    ['#fb9a99', 'black'],
+    ['#fdbf6f', 'black'],
+    ['#cab2d6', 'black'],
+    ['#ffff99', 'black'],
+    ['#1f78b4', 'white'],
+    ['#33a02c', 'white'],
+    ['#e31a1c', 'white'],
+    ['#ff7f00', 'white'],
+    ['#6a3d9a', 'white'],
+    ['#b15928', 'white']
+  ];
 
   var tagsByFrequency;
 
@@ -93,7 +108,7 @@
 
       // HTML for each tag, unique color for each tag
       var tagsHTML = transIdToTags[transId].map(function(tag) {
-        return '<span class="gm-tag" style="background-color: ' + tagColorLookup(tag) + '; ' + SINGLE_TAG_STYLE + '">' + tag + '</span>';
+        return '<span class="gm-tag" style="' + tagStyleLookup(tag) + '; ' + SINGLE_TAG_STYLE + '">' + tag + '</span>';
       }).join('');
 
       $td.find('.gm-tags').html(tagsHTML);
@@ -177,9 +192,10 @@
     observeDOM(target);
   })();
 
-  function tagColorLookup(tag) {
+  function tagStyleLookup(tag) {
     var index = tagsByFrequency.indexOf(tag);
-    return TAG_COLORS[index % TAG_COLORS.length];
+    var colors = TAG_COLORS[index % TAG_COLORS.length];
+    return 'background-color: ' + colors[0] + '; color: ' + colors[1] + ';';
   }
 
 })();

--- a/mint-tags-display.user.js
+++ b/mint-tags-display.user.js
@@ -106,6 +106,13 @@
         $td.append('<span class="gm-tags" style="' + TAG_STYLE + '"></span>');
       }
 
+      // Alphabetize
+      transIdToTags[transId].sort(function(a, b) {
+        if(a.toLowerCase() < b.toLowerCase()) { return -1; }
+        else if(a.toLowerCase() > b.toLowerCase()) { return 1; }
+        else { return 0; }
+      });
+
       // HTML for each tag, unique color for each tag
       var tagsHTML = transIdToTags[transId].map(function(tag) {
         return '<span class="gm-tag" style="' + tagStyleLookup(tag) + '; ' + SINGLE_TAG_STYLE + '">' + tag + '</span>';


### PR DESCRIPTION
Using a [12-color palette](http://colorbrewer2.org/#type=qualitative&scheme=Paired&n=12) from Colorbrewer, assigning colors in order of frequency of use.

@misterbrandt kicked this off with #2, I'm just bringing it to completion here.

(Also: alphabetize tags)
